### PR TITLE
build: resolve Windows compatibility in make all command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ else
 	API_PROTO_FILES=$(shell find proto/api -name *.proto)
 endif
 
-path := $(shell pwd)
 
 .PHONY: init
 # init env
@@ -61,7 +60,7 @@ api:
 
 .PHONY: stringer
 stringer:
-	go generate $(path)/pkg/vobj
+	cd ./pkg/vobj && go generate
 
 .PHONY: generate
 # generate


### PR DESCRIPTION
Fix path handling issues causing make stringer to fail on Windows Git Bash environments