### PR TITLE
fix: resolve duplicate method declarations in ent-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+.vscode
 .idea
 *.string.go
 /internal/data/ent/*

--- a/internal/data/ent/schema/user.go
+++ b/internal/data/ent/schema/user.go
@@ -34,7 +34,7 @@ func (User) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("refresh_token", RefreshToken.Type),
 		edge.To("trip", Trip.Type),
-		edge.From("trips", Trip.Type).Ref("collaborators"),
+		edge.From("collaborated_trips", Trip.Type).Ref("collaborators"),
 	}
 }
 


### PR DESCRIPTION
Old `edge.From("trips", Trip.Type).Ref("collaborators")` causes Ent to generate functions with the same name, resulting in build errors. Modify the edge name to avoid this problem.